### PR TITLE
Use relative path when calling dmypy

### DIFF
--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -363,6 +363,10 @@ def get_diagnostics(
                 )
                 mypy_api.run_dmypy(["--status-file", dmypy_status_file, "restart"])
 
+        # Use relative path of file
+        filepath_idx = args.index(document.path)
+        args[filepath_idx] = os.path.relpath(document.path)
+
         # run to use existing daemon or restart if required
         args = ["--status-file", dmypy_status_file, "run", "--"] + apply_overrides(args, overrides)
         if shutil.which("dmypy"):


### PR DESCRIPTION
I've found dmypy + pylsp-mypy uses full filepaths and it tends to break in my development environment (Ubuntu 22.04). 

The break occurs when using vim-lsp + python-lsp-server + pylsp-mypy. I will introduce a type error and wait for the lsp+dmypy linting to occur. The first run of lint will take a while because it starts up the server. The second run executes quickly and succeeds but will not show the type error. 

After some late-night debugging, I found that if I passed the relative file path to `dmypy,` the linting executes as expected (shows errors in Vim).

```
pip install git+https://github.com/pbui-patreon/pylsp-mypy.git@dmypy-with-relative-filepaths
``` 